### PR TITLE
kitti evaluation of split ranges

### DIFF
--- a/tools/merge_predictions/evaluate_kitti_range.py
+++ b/tools/merge_predictions/evaluate_kitti_range.py
@@ -13,10 +13,11 @@ GROUND_TRUTH_FILE = '../../data/kitti/kitti_infos_val.pkl'
 
 def parse_config():
     parser = argparse.ArgumentParser(description='Evaluate kitti results based on saved prediction results.')
+    parser.add_argument('--range_cutoff', type=float, default=34.0, help='The cutoff value to merge or split short and long range result.')
     parser.add_argument('--full_range_result', type=str, default=None, help='The full range validation result pickle file.')
     parser.add_argument('--short_range_result', type=str, default=None, help='The short range validation result pickle file.')
     parser.add_argument('--long_range_result', type=str, default=None, help='The short range validation result pickle file.')
-    parser.add_argument('--merge_range_cutoff', type=float, default=34.0, help='The cutoff value to merge the short and long range result.')
+    parser.add_argument('--save_merge_result', action='store_true', default=False, help='If present, save merge result pickle file to working directory.')
 
     args = parser.parse_args()
     return args, parser
@@ -31,12 +32,30 @@ def print_eval_result(ap_result_str, ap_dict):
     # print(ap_dict)
     print('Easy: {:.2f}   Moderate: {:.2f}   Hard: {:.2f}\n'.format( ap_dict['Car_3d/easy_R40'], ap_dict['Car_3d/moderate_R40'], ap_dict['Car_3d/hard_R40'] ))
 
+def split_result_by_range(full_range_result: [], cutoff_distance: float)-> ([],[]):
+    short_range_result, long_range_result = [], []
+    for det in full_range_result:
+        short_detections, long_detections = {}, {}
+        indexes_for_short = det['location'][:,2] < cutoff_distance - 0.27
+        indexes_for_long = det['location'][:,2] > cutoff_distance - 0.27
+        for key, val in det.items():
+            if key != 'frame_id' and key != 'gt_boxes_lidar':
+                short_detections[key] = det[key][indexes_for_short]
+                long_detections[key] = det[key][indexes_for_long]
+        if 'frame_id' in det:
+            short_detections['frame_id'] = det['frame_id']
+            long_detections['frame_id'] = det['frame_id']
+        short_range_result.append(short_detections)
+        long_range_result.append(long_detections)
+    return short_range_result, long_range_result
+
 def main():
     args, parser = parse_config()
     current_folder = os.path.abspath(os.path.dirname(__file__)) + '/'
 
     groundtruth = read_pickle_file(os.path.join(current_folder,GROUND_TRUTH_FILE))
-    eval_gt_annos = [copy.deepcopy(info['annos']) for info in groundtruth]
+    eval_gt_full = [copy.deepcopy(info['annos']) for info in groundtruth]
+    eval_gt_short, eval_gt_long = split_result_by_range(eval_gt_full, args.range_cutoff)
 
     show_help = True
 
@@ -44,26 +63,52 @@ def main():
     if args.full_range_result is not None:
         show_help = False
         full_range_result = read_pickle_file(args.full_range_result)
-        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_annos, full_range_result, 'Car')
+        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_full, full_range_result, 'Car')
     
-        print('\nModel trained with full range data:')
+        print('\n******** Model trained with full range data ********')
+        print_eval_result(ap_result_str, ap_dict)
+
+        print('  - Splitting result to evaluate on range...')
+        split_result_short, split_result_long = split_result_by_range(full_range_result, args.range_cutoff)
+        
+        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_short, split_result_short, 'Car')
+        print('  - Accuracy on range 0-{:.1f}:'.format(args.range_cutoff))
+        print_eval_result(ap_result_str, ap_dict)
+
+        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_long, split_result_long, 'Car')
+        print('  - Accuracy on range {:.1f}-70:'.format(args.range_cutoff))
         print_eval_result(ap_result_str, ap_dict)
 
     # Evaluation of merged result from models handling separate ranges
     if args.long_range_result is not None and args.short_range_result is not None:
         show_help = False
-        print('\nMerged result from models handling separate ranges:')
         short_range_result = read_pickle_file(args.short_range_result)
         long_range_result = read_pickle_file(args.long_range_result)
 
         merged_result = merge_results_all(short_range_result, long_range_result)
-        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_annos, merged_result, 'Car')
-        print('\n- Merge all:')
+        if args.save_merge_result:
+            with open('merge_all_result.pkl', 'wb') as f:
+                pickle.dump(merged_result, f)
+        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_full, merged_result, 'Car')
+        print('\n******** Merged result from models handling separate ranges ********')
+        print('  - Merge all:')
         print_eval_result(ap_result_str, ap_dict)
 
-        merged_result = merge_results_within_range(short_range_result, long_range_result, args.merge_range_cutoff)
-        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_annos, merged_result, 'Car')
-        print('\n- Merge with range cutoff at {}:'.format(args.merge_range_cutoff))
+        merged_result = merge_results_within_range(short_range_result, long_range_result, args.range_cutoff)
+        if args.save_merge_result:
+            with open('merge_with_cutoff_{:.0f}_result.pkl'.format(args.range_cutoff), 'wb') as f:
+                pickle.dump(merged_result, f)
+        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_full, merged_result, 'Car')
+        print('  - Merge with range cutoff at {}:'.format(args.range_cutoff))
+        print_eval_result(ap_result_str, ap_dict)
+
+        split_result_short, split_result_long = split_result_by_range(merged_result, args.range_cutoff)
+        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_short, split_result_short, 'Car')
+        print('  - Accuracy on range 0-{:.1f}:'.format(args.range_cutoff))
+        print_eval_result(ap_result_str, ap_dict)
+
+        ap_result_str, ap_dict = kitti_eval.get_official_eval_result(eval_gt_long, split_result_long, 'Car')
+        print('  - Accuracy on range {:.1f}-70:'.format(args.range_cutoff))
         print_eval_result(ap_result_str, ap_dict)
 
     if show_help:


### PR DESCRIPTION
Produce kitti evaluation separately on short and long range by splitting the ground truth data based on cutoff range value.

Also save merge result into pickle file.

```
python tools/merge_predictions/evaluate_kitti_range.py --short_range_result=tools/merge_predictions/result_short.pkl --long_range_result=tools/merge_predictions/result_long.pkl --save_merge_result

******** Merged result from models handling separate ranges ********
  - Merge all:
Easy: 87.52   Moderate: 76.79   Hard: 73.70

  - Merge with range cutoff at 34.0:
Easy: 87.96   Moderate: 78.56   Hard: 75.87

  - Accuracy on range 0-34.0:
Easy: 89.65   Moderate: 88.30   Hard: 84.99

  - Accuracy on range 34.0-70:
Easy: 0.45   Moderate: 41.35   Hard: 38.89
```

```
python tools/merge_predictions/evaluate_kitti_range.py --full_range_result tools/merge_predictions/result_fr.pkl

******** Model trained with full range data ********
Easy: 88.08   Moderate: 79.17   Hard: 76.29

  - Splitting result to evaluate on range...
  - Accuracy on range 0-34.0:
Easy: 89.71   Moderate: 88.34   Hard: 85.15

  - Accuracy on range 34.0-70:
Easy: 3.50   Moderate: 47.31   Hard: 44.36
```